### PR TITLE
Run `git fetch` before switching branches

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,6 +55,8 @@ deploy-github-pages:
   dependencies:
     - web
   script:
+    # This ensures the `gh-pages` branch is available.
+    - git fetch
     - git checkout gh-pages
     - rm -f *.md
     - mv build/web/** .
@@ -71,6 +73,8 @@ pages:
   dependencies:
     - web
   script:
+    # This ensures the `pages` branch is available.
+    - git fetch
     - git checkout pages
     - rm -f *.md
     - mv build/web/** ./public


### PR DESCRIPTION
This ensures the desired branch is available. I'm not sure if there are any other implications by running this, so please check.

This closes #9.