### PR TITLE
Add caching for imported assets

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,11 @@
 image: barichello/godot-ci:3.2.1
 
+# Cache imported assets between runs
+cache:
+  key: import-assets
+  paths:
+  - .import/
+  
 stages:
   - export
   - deploy


### PR DESCRIPTION
This enables caching for imported assets between each run. This massively speeds up the export stage for big projects (which needs ~30 minutes to import 150MB for a 3D project).

Note that this saves the cache *after* a stage is done so it is not shared by the 3 platforms if they run in parallel. So if you add new files it will still import them once for each platform (but will not import them again in the future, which is what matters).