### PR TITLE
Build mono docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ https://hub.docker.com/r/barichello/godot-ci/
 - Repository examples: [test-project](https://github.com/aBARICHELLO/godot-ci/tree/master/test-project) | [game-off](https://gitlab.com/BARICHELLO/game-off).
 - Test deploys using this tool: [GitHub Pages](http://barichello.me/godot-ci/) | [GitLab Pages](https://barichello.gitlab.io/godot-ci/) | [Itch.io](https://barichello.itch.io/test-project).
 
+### Mono/C#
+
+To build a godot project with Mono enabled, change the image tag from `barichello/godot-ci:VERSION` to `barichello/godot-ci:mono-VERSION` in `.gitlab-ci.yml` (Gitlab) or `godot-ci.yml` (Github). e.g. `barichello/godot-ci:mono-3.2.1`.
+
 ## Platforms
 
 Here's a mapping between each supported CI service, the template jobs and a live example.

--- a/mono.Dockerfile
+++ b/mono.Dockerfile
@@ -1,0 +1,46 @@
+FROM mono:latest
+LABEL author="artur@barichello.me,asheraryam@gmail.com"
+
+
+USER root
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    git \
+    python \
+    python-openssl \
+    unzip \
+    wget \
+    zip \
+    && rm -rf /var/lib/apt/lists/*
+
+# When in doubt see the downloads page
+# https://downloads.tuxfamily.org/godotengine/
+ENV GODOT_VERSION "3.2.1"
+
+# Example values: stable, beta1, rc2, alpha3, etc.
+# Also change the SUBDIR property when NOT using stable
+ENV RELEASE_NAME "stable"
+
+# This is only needed for non-stable builds (alpha, beta, RC)
+# e.g. SUBDIR "/beta1"
+ENV SUBDIR "" 
+
+RUN wget https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}${SUBDIR}/mono/Godot_v${GODOT_VERSION}-${RELEASE_NAME}_mono_linux_headless_64.zip \
+    && wget https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}${SUBDIR}/mono/Godot_v${GODOT_VERSION}-${RELEASE_NAME}_mono_export_templates.tpz
+
+RUN mkdir ~/.cache \
+    && mkdir -p ~/.config/godot \
+    && mkdir -p ~/.local/share/godot/templates/${GODOT_VERSION}.${RELEASE_NAME}.mono \
+    && unzip Godot_v${GODOT_VERSION}-${RELEASE_NAME}_mono_linux_headless_64.zip \
+    && mv Godot_v${GODOT_VERSION}-${RELEASE_NAME}_mono_linux_headless_64/Godot_v${GODOT_VERSION}-${RELEASE_NAME}_mono_linux_headless.64 /usr/local/bin/godot \
+    && mv Godot_v${GODOT_VERSION}-${RELEASE_NAME}_mono_linux_headless_64/GodotSharp /usr/local/bin/GodotSharp \
+    && unzip Godot_v${GODOT_VERSION}-${RELEASE_NAME}_mono_export_templates.tpz \
+    && mv templates/* ~/.local/share/godot/templates/${GODOT_VERSION}.${RELEASE_NAME}.mono \
+    && rm -f Godot_v${GODOT_VERSION}-${RELEASE_NAME}_mono_export_templates.tpz Godot_v${GODOT_VERSION}-${RELEASE_NAME}_mono_linux_headless_64.zip
+
+ADD getbutler.sh /opt/butler/getbutler.sh
+RUN bash /opt/butler/getbutler.sh
+RUN /opt/butler/bin/butler -V
+
+ENV PATH="/opt/butler/bin:${PATH}"


### PR DESCRIPTION
This does the required changes to build a godot+mono in a docker container.

I think we might want to make a separate branch for mono and merge this to that.

Note that this only changes the Dockerfile and does not edit the `gitlab-ci.yml` since I think we will want to link to a different dockerhub

Part of https://github.com/aBARICHELLO/godot-ci/issues/17