### PR TITLE
Use latest beta for mono image

### DIFF
--- a/mono.Dockerfile
+++ b/mono.Dockerfile
@@ -16,15 +16,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # When in doubt see the downloads page
 # https://downloads.tuxfamily.org/godotengine/
-ENV GODOT_VERSION "3.2.1"
+ENV GODOT_VERSION "3.2.2"
 
 # Example values: stable, beta1, rc2, alpha3, etc.
 # Also change the SUBDIR property when NOT using stable
-ENV RELEASE_NAME "stable"
+ENV RELEASE_NAME "beta3"
 
 # This is only needed for non-stable builds (alpha, beta, RC)
 # e.g. SUBDIR "/beta1"
-ENV SUBDIR "" 
+ENV SUBDIR "/beta3" 
 
 RUN wget https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}${SUBDIR}/mono/Godot_v${GODOT_VERSION}-${RELEASE_NAME}_mono_linux_headless_64.zip \
     && wget https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}${SUBDIR}/mono/Godot_v${GODOT_VERSION}-${RELEASE_NAME}_mono_export_templates.tpz


### PR DESCRIPTION
When I submitted the image in https://github.com/aBARICHELLO/godot-ci/pull/16 I made it use the stable version so we can build 3.2.1 from the master branch.

I've been using the beta for a while so I already tested this (see [builds here](https://hub.docker.com/repository/docker/asheraryam/godot-mono-ci/tags?page=1) on dockerhub).

If you'd like I can also submit a similar PR for the non-mono version.