### PR TITLE
Deploy to GitHub Pages from GitHub Actions

### DIFF
--- a/.github/workflows/godot-ci.yml
+++ b/.github/workflows/godot-ci.yml
@@ -74,6 +74,16 @@ jobs:
         with:
           name: web
           path: build/web
+      # Installing rsync is needed in order to deploy to GitHub Pages. Without it, the build will fail.
+      - name: Install rsync 📚
+        run: |
+          apt-get update && apt-get install -y rsync
+      - name: Deploy to GitHub Pages 🚀
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages # The branch the action should deploy to.
+          FOLDER: build/web # The folder the action should deploy.
 
   export-mac:
     name: Mac Export


### PR DESCRIPTION
This lets godot-ci.yml deploy to GitHub Pages after a Web Build is exported. Thanks to https://github.com/JamesIves/github-pages-deploy-action

If you encounter issues when deploying to gh-pages, try to change the theme from the repository's settings.

This addresses a part of #14.