### PR TITLE
Add a link to David Snopek's video tutorial series about Godot and GiitLab CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ https://hub.docker.com/r/barichello/godot-ci/
 <br>For live projects, examples and tutorials using this template check the list below:<br>
 
 - [Video tutorial by Kyle Luce](https://www.youtube.com/watch?v=wbc1qut0vT4)
+- [Video tutorial series by David Snopek](https://www.youtube.com/watch?v=4oUs4IV_Mj4&list=PLCBLMvLIundAOAiCvluBNuEA0-ea7_EDp)
 - Repository examples: [test-project](https://github.com/aBARICHELLO/godot-ci/tree/master/test-project) | [game-off](https://gitlab.com/BARICHELLO/game-off).
 - Test deploys using this tool: [GitHub Pages](http://barichello.me/godot-ci/) | [GitLab Pages](https://barichello.gitlab.io/godot-ci/) | [Itch.io](https://barichello.itch.io/test-project).
 


### PR DESCRIPTION
First of all, thanks so much for maintaining this project and always making sure that you have a new Docker image up when new Godot versions come out! It's wonderful that the community has this valuable resource available. :-)

I noticed that you put a link to Kyle Luce's video tutorial in the README.md, and I was wondering if you'd be willing to put a link to my video tutorial series as well?

The first part is up and it covers using this image for exporting to Windows, Linux, Windows and HTML5, and deploying to GitLab Pages. Future parts will cover deploying to Itch.io (and other places), more advanced exports (ex. Android) and using custom builds of Godot.

Anyway, thanks again for your work on this project! I'd love to chat sometime via email or Discord or whatever. :-)