### PR TITLE
Update mono docker to 3.2.3

### DIFF
--- a/mono.Dockerfile
+++ b/mono.Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # When in doubt see the downloads page
 # https://downloads.tuxfamily.org/godotengine/
-ENV GODOT_VERSION "3.2.2"
+ENV GODOT_VERSION "3.2.3"
 
 # Example values: stable, beta3, rc1, alpha2, etc.
 # Also change the SUBDIR property when NOT using stable


### PR DESCRIPTION
The engine changes do not affect the docker process so changing the version variable in the script is all we need to do.