### PR TITLE
add wine, rcedit, update to focal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,12 +18,12 @@ RUN apt-get update && apt-get full-upgrade --yes && apt-get install --yes --no-i
     wine-stable \
     && rm -rf /var/lib/apt/lists/*
 
-RUN wget --quiet https://github.com/electron/rcedit/releases/download/v1.1.1/rcedit-x64.exe -O /usr/local/bin/rcedit.exe
+RUN wget --no-verbose https://github.com/electron/rcedit/releases/download/v1.1.1/rcedit-x64.exe -O /usr/local/bin/rcedit.exe
 
 ENV GODOT_VERSION "3.2.3"
 
-RUN wget --quiet https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}/Godot_v${GODOT_VERSION}-stable_linux_headless.64.zip \
-    && wget --quiet https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}/Godot_v${GODOT_VERSION}-stable_export_templates.tpz \
+RUN wget --no-verbose https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}/Godot_v${GODOT_VERSION}-stable_linux_headless.64.zip \
+    && wget --no-verbose https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}/Godot_v${GODOT_VERSION}-stable_export_templates.tpz \
     && mkdir ~/.cache \
     && mkdir -p ~/.config/godot \
     && mkdir -p ~/.local/share/godot/templates/${GODOT_VERSION}.stable \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
-FROM ubuntu:bionic
+FROM ubuntu:focal
 LABEL author="artur@barichello.me"
 
 USER root
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get full-upgrade --yes && apt-get install --yes --no-install-recommends \
     ca-certificates \
     git \
+    git-lfs \
     python \
     python-openssl \
     unzip \
@@ -13,12 +14,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     zip \
     adb \
     openjdk-8-jdk-headless \
+    imagemagick \
+    wine-stable \
     && rm -rf /var/lib/apt/lists/*
+
+RUN wget --quiet https://github.com/electron/rcedit/releases/download/v1.1.1/rcedit-x64.exe -O /usr/local/bin/rcedit.exe
 
 ENV GODOT_VERSION "3.2.3"
 
-RUN wget https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}/Godot_v${GODOT_VERSION}-stable_linux_headless.64.zip \
-    && wget https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}/Godot_v${GODOT_VERSION}-stable_export_templates.tpz \
+RUN wget --quiet https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}/Godot_v${GODOT_VERSION}-stable_linux_headless.64.zip \
+    && wget --quiet https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}/Godot_v${GODOT_VERSION}-stable_export_templates.tpz \
     && mkdir ~/.cache \
     && mkdir -p ~/.config/godot \
     && mkdir -p ~/.local/share/godot/templates/${GODOT_VERSION}.stable \

--- a/getbutler.sh
+++ b/getbutler.sh
@@ -3,7 +3,7 @@
 mkdir -p /opt/butler/bin 
 cd /opt/butler/bin
 
-wget -O butler.zip https://broth.itch.ovh/butler/linux-amd64/LATEST/archive/default
+wget --no-verbose -O butler.zip https://broth.itch.ovh/butler/linux-amd64/LATEST/archive/default
 unzip butler.zip
 
 # GNU unzip tends to not set the executable bit even though it's set in the .zip


### PR DESCRIPTION
This PR does the following:

- Updates Ubuntu to focal, by using the latest version of git we can use the [Checkout action v2](https://github.com/marketplace/actions/checkout)
- Installs wine, this is required to use rcedit
- Downloads rcedit to /usr/loca/bin, required to change / correct the icon on build Windows executables
- Makes downloads quiet, less spam in the build log

_Contributor Edit:_
Fixes https://github.com/aBARICHELLO/godot-ci/issues/21