### PR TITLE
Add base64 command for windows, Fix type from variable to file

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -70,8 +70,10 @@ android_debug:
       - build/android
 
 # Android Release Job. You will need to include keystore and password in the GitLab variable settings: 
-# 1. Take your generated keystore and convert it to base64: base64 release.keystore -w 0
-# 2. Go to Gitlab Project > Settings > CI/CD > Variables and copy the base64 keystore value in a new variable SECRET_RELEASE_KEYSTORE_BASE64 as type file
+# 1. Take your generated keystore and convert it to base64: 
+#   Linux & macOS: `base64 release.keystore -w 0`  
+#   Windows: `certutil -encodehex -f release.keystore encoded.txt 0x40000001`  
+# 2. Go to Gitlab Project > Settings > CI/CD > Variables and copy the base64 keystore value in a new variable SECRET_RELEASE_KEYSTORE_BASE64 as type variable.
 # 3. Create a second variable SECRET_RELEASE_KEYSTORE_USER as type variable with the alias of your keystore as value.
 # 4. Create a third variable SECRET_RELEASE_KEYSTORE_PASSWORD as type variable with the password of your keystore as value.
 android:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -70,10 +70,10 @@ android_debug:
       - build/android
 
 # Android Release Job. You will need to include keystore and password in the GitLab variable settings: 
-# 1. Take your generated keystore and convert it to base64: 
+# 1. Take your generated keystore and convert it to Base64: 
 #   Linux & macOS: `base64 release.keystore -w 0`  
 #   Windows: `certutil -encodehex -f release.keystore encoded.txt 0x40000001`  
-# 2. Go to Gitlab Project > Settings > CI/CD > Variables and copy the base64 keystore value in a new variable SECRET_RELEASE_KEYSTORE_BASE64 as type variable.
+# 2. Go to GitLab Project > Settings > CI/CD > Variables and copy the Base64-encoded keystore value in a new variable `SECRET_RELEASE_KEYSTORE_BASE64` as type variable.
 # 3. Create a second variable SECRET_RELEASE_KEYSTORE_USER as type variable with the alias of your keystore as value.
 # 4. Create a third variable SECRET_RELEASE_KEYSTORE_PASSWORD as type variable with the password of your keystore as value.
 android:

--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@ To build a godot project with Mono enabled, change the image tag from `barichell
 To build a debug release (debug.keystore), use the `android_debug` job example in the `gitlab-ci.yml` file.
 
 If you want to export for Android with your own keystore, you can do this with the following steps:
-1. Take your generated keystore and convert it to base64: `base64 release.keystore -w 0`
-2. Go to Gitlab Project > Settings > CI/CD > Variables and copy the base64 keystore value in a new variable SECRET_RELEASE_KEYSTORE_BASE64 as type file
+1. Take your generated keystore and convert it to base64:  
+Linux & macOS: `base64 release.keystore -w 0`  
+Windows: `certutil -encodehex -f release.keystore encoded.txt 0x40000001`  
+2. Go to Gitlab Project > Settings > CI/CD > Variables and copy the base64 keystore value in a new variable SECRET_RELEASE_KEYSTORE_BASE64 as type variable.
 3. Create a second variable SECRET_RELEASE_KEYSTORE_USER as type variable with the alias of your keystore as value.
 4. Create a third variable SECRET_RELEASE_KEYSTORE_PASSWORD as type variable with the password of your keystore as value.
 5. Use the `android` job example in the `gitlab-ci.yml` file.

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ To build a godot project with Mono enabled, change the image tag from `barichell
 To build a debug release (debug.keystore), use the `android_debug` job example in the `gitlab-ci.yml` file.
 
 If you want to export for Android with your own keystore, you can do this with the following steps:
-1. Take your generated keystore and convert it to base64:  
+1. Take your generated keystore and convert it to Base64:  
 Linux & macOS: `base64 release.keystore -w 0`  
 Windows: `certutil -encodehex -f release.keystore encoded.txt 0x40000001`  
-2. Go to Gitlab Project > Settings > CI/CD > Variables and copy the base64 keystore value in a new variable SECRET_RELEASE_KEYSTORE_BASE64 as type variable.
+2. Go to **GitLab Project > Settings > CI/CD > Variables** and copy the Base64-encoded keystore value in a new variable `SECRET_RELEASE_KEYSTORE_BASE64` as type variable.
 3. Create a second variable SECRET_RELEASE_KEYSTORE_USER as type variable with the alias of your keystore as value.
 4. Create a third variable SECRET_RELEASE_KEYSTORE_PASSWORD as type variable with the password of your keystore as value.
 5. Use the `android` job example in the `gitlab-ci.yml` file.


### PR DESCRIPTION
Hello!

When setting up the Android Release CI on Gitlab there was some confusion regarding the necessary **type** of variable that had to be created. Since the README and YML both clearly state that it has to be saved a file-type CI variable while the YML commands expect to receive a variable (with the echo-command).

After a short discussion with @asheraryam it was decided that, to avoid any further confusion, this should be updated.

Also, since base64 is not natively available on Windows OS, I added a native command that does the same thing in Windows, so poor users don't have to download any external software and can just exploit the native toolset 😢 

Greetings!