### PR TITLE
chore(git): version for LFS dependency

### DIFF
--- a/.github/workflows/godot-ci.yml
+++ b/.github/workflows/godot-ci.yml
@@ -13,7 +13,9 @@ jobs:
       image: barichello/godot-ci:3.2.3
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
+        with:
+          lfs: true
       - name: Setup
         run: |
           mkdir -v -p ~/.local/share/godot/templates
@@ -36,7 +38,9 @@ jobs:
       image: barichello/godot-ci:3.2.3
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
+        with:
+          lfs: true
       - name: Setup
         run: |
           mkdir -v -p ~/.local/share/godot/templates
@@ -59,7 +63,9 @@ jobs:
       image: barichello/godot-ci:3.2.3
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
+        with:
+          lfs: true
       - name: Setup
         run: |
           mkdir -v -p ~/.local/share/godot/templates
@@ -92,7 +98,9 @@ jobs:
       image: barichello/godot-ci:3.2.3
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
+        with:
+          lfs: true
       - name: Setup
         run: |
           mkdir -v -p ~/.local/share/godot/templates

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM ubuntu:focal
 LABEL author="artur@barichello.me"
 
 USER root


### PR DESCRIPTION
So regarding #43 and my last pull request adding git lfs to the dependencies; to actually be able to use LFS in the actions pipeline, you need a minimum of git version 2.18.

Ubuntu Bionic defaults to 2.17.1 :frowning: 

There are two solutions here, to use `ubuntu: focal` as the image (the current LTS build)

Or add the PPA repository while installing the other dependencies

```
sudo add-apt-repository ppa:git-core/ppa
sudo apt update
sudo apt install git
```

Not sure which one falls better in line with the strategy of Godot-CI? However, I'm not sure how that might affect the Mono Dockerfile, since I can't really find what that image is based on.