### PR TITLE
Add additional resources for other CI needs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ See [this repository](https://github.com/2shady4u/godot-cpp-ci) for automating G
 
 You have to compile the modules with godot first, see [this excellent repository](https://gitlab.com/Calinou/godot-builds-ci) by Calinou for automating godot builds. 
 
-After that you would use the custom build to export your project as usual, see [this guide](https://gitlab.com/greenfox/godot-build-automation/-/blob/master/advanced_topics.md#using-a-custom-build-of-godot) by Greenfox on how to do use a custom godot build for automated exports.
+After that you would use the custom build to export your project as usual, see [this guide](https://gitlab.com/greenfox/godot-build-automation/-/blob/master/advanced_topics.md#using-a-custom-build-of-godot) by Greenfox on how to use a custom godot build for automated exports.
 
 ### iOS
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ See [this repository](https://github.com/2shady4u/godot-cpp-ci) for automating G
 
 You have to compile Godot with the modules included first. See [this excellent repository](https://gitlab.com/Calinou/godot-builds-ci) by Calinou for automating Godot builds. 
 
-After that you would use the custom build to export your project as usual, see [this guide](https://gitlab.com/greenfox/godot-build-automation/-/blob/master/advanced_topics.md#using-a-custom-build-of-godot) by Greenfox on how to use a custom godot build for automated exports.
+After that, you would use the custom build to export your project as usual. See [this guide](https://gitlab.com/greenfox/godot-build-automation/-/blob/master/advanced_topics.md#using-a-custom-build-of-godot) by Greenfox on how to use a custom Godot build for automated exports.
 
 ### iOS
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ See [this repository](https://github.com/2shady4u/godot-cpp-ci) for automating G
 
 ### Modules
 
-You have to compile the modules with godot first, see [this excellent repository](https://gitlab.com/Calinou/godot-builds-ci) by Calinou for automating godot builds. 
+You have to compile Godot with the modules included first. See [this excellent repository](https://gitlab.com/Calinou/godot-builds-ci) by Calinou for automating Godot builds. 
 
 After that you would use the custom build to export your project as usual, see [this guide](https://gitlab.com/greenfox/godot-build-automation/-/blob/master/advanced_topics.md#using-a-custom-build-of-godot) by Greenfox on how to use a custom godot build for automated exports.
 

--- a/README.md
+++ b/README.md
@@ -97,4 +97,4 @@ Secrets needed for a Itch.io deploy via GitLab CI:
 
 ## Additional Resources
 
-Greenfox has an [excellent repo](https://gitlab.com/greenfox/godot-build-automation) that is also for automating godot exports.
+Greenfox has an [excellent repo](https://gitlab.com/greenfox/godot-build-automation) that is also for automating Godot exports.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ After that, you would use the custom build to export your project as usual. See 
 
 ### iOS
 
-Not available yet. Automating xcode projects is doable but not trivial, and mac runners only recently became available for github actions, so it will happen eventually.
+Not available yet. Automating Xcode projects is doable but not trivial, and macOS runners only recently became available for GitHub actions, so it will happen eventually.
 
 ## Platforms
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,20 @@ Windows: `certutil -encodehex -f release.keystore encoded.txt 0x40000001`
 4. Create a third variable SECRET_RELEASE_KEYSTORE_PASSWORD as type variable with the password of your keystore as value.
 5. Use the `android` job example in the `gitlab-ci.yml` file.
 
+### GDNative/C++
+
+See [this repository](https://github.com/2shady4u/godot-cpp-ci) for automating GDNative C++ compilation, which is based off this repository.
+
+### Modules
+
+You have to compile the modules with godot first, see [this excellent repository](https://gitlab.com/Calinou/godot-builds-ci) by Calinou for automating godot builds. 
+
+After that you would use the custom build to export your project as usual, see [this guide](https://gitlab.com/greenfox/godot-build-automation/-/blob/master/advanced_topics.md#using-a-custom-build-of-godot) by Greenfox on how to do use a custom godot build for automated exports.
+
+### iOS
+
+Not available yet. Automating xcode projects is doable but not trivial, and mac runners only recently became available for github actions, so it will happen eventually.
+
 ## Platforms
 
 Here's a mapping between each supported CI service, the template jobs and a live example.
@@ -80,3 +94,7 @@ Secrets needed for a Itch.io deploy via GitLab CI:
 
 #### Authentication errors with Butler
 - If using GitLab check that the 'protected' tag is disabled in the [CI/CD variables panel](https://github.com/aBARICHELLO/godot-ci#environment-configuration).
+
+## Additional Resources
+
+Greenfox has an [excellent repo](https://gitlab.com/greenfox/godot-build-automation) that is also for automating godot exports.


### PR DESCRIPTION
This adds links to external projects that cover areas that we miss. We can possibly expand to include some of them later, like C++ compilation, but until then it's necessary to refer to them.

This mentions @2shady4u @Calinou [@Greenfox](https://gitlab.com/greenfox)