### PR TITLE
Remove needless cd from gitlab-ci.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,8 @@
 image: barichello/godot-ci:3.2.3
 
+# NOTE: the `cd` command in each build stage is not necessary if your
+# project.godot is at the repo root
+
 # Cache imported assets between runs
 cache:
   key: import-assets


### PR DESCRIPTION
It seems that the workdir for gitlab is already inside the cloned repo,
so `cd $EXPORT_NAME` will fail.

Here's a build that prints `pwd` to demonstrate:
https://gitlab.com/rcorre/weekly-game-jam-204/-/jobs/1318895344

Here's a pipeline that passed after removing `cd`:
- https://gitlab.com/rcorre/weekly-game-jam-204/-/pipelines/315008027
- https://gitlab.com/rcorre/weekly-game-jam-204/-/commit/1af90b1fa2b9b74abb3e50a022809d700350bc10.
