### PR TITLE
Add downloading of android-sdk and required components

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,12 +35,24 @@ RUN /opt/butler/bin/butler -V
 
 ENV PATH="/opt/butler/bin:${PATH}"
 
+# Download and setup android-sdk
+ENV ANDROID_HOME="/usr/lib/android-sdk"
+RUN wget https://dl.google.com/android/repository/commandlinetools-linux-7583922_latest.zip \
+    && unzip commandlinetools-linux-*_latest.zip -d cmdline-tools \
+    && mv cmdline-tools $ANDROID_HOME/ \
+    && rm -f commandlinetools-linux-*_latest.zip
+
+ENV PATH="${ANDROID_HOME}/cmdline-tools/cmdline-tools/bin:${PATH}"
+
+RUN yes | sdkmanager --licenses \
+    && sdkmanager "platform-tools" "build-tools;30.0.3" "platforms;android-29" "cmdline-tools;latest" "cmake;3.10.2.4988404" "ndk;21.4.7075529"
+
 # Adding android keystore and settings
 RUN keytool -keyalg RSA -genkeypair -alias androiddebugkey -keypass android -keystore debug.keystore -storepass android -dname "CN=Android Debug,O=Android,C=US" -validity 9999 \
     && mv debug.keystore /root/debug.keystore
+
 RUN godot -e -q
-RUN echo 'export/android/adb = "/usr/bin/adb"' >> ~/.config/godot/editor_settings-3.tres
-RUN echo 'export/android/jarsigner = "/usr/bin/jarsigner"' >> ~/.config/godot/editor_settings-3.tres
+RUN echo 'export/android/android_sdk_path = "/usr/lib/android-sdk"' >> ~/.config/godot/editor_settings-3.tres
 RUN echo 'export/android/debug_keystore = "/root/debug.keystore"' >> ~/.config/godot/editor_settings-3.tres
 RUN echo 'export/android/debug_keystore_user = "androiddebugkey"' >> ~/.config/godot/editor_settings-3.tres
 RUN echo 'export/android/debug_keystore_pass = "android"' >> ~/.config/godot/editor_settings-3.tres


### PR DESCRIPTION
Just added downloading of android-sdk and installing all required components. With these changes export for android should work correctly.

Should fix #59 

Also removed settings for adb and jarsigner, as mentioned [here](https://github.com/abarichello/godot-ci/issues/68#issuecomment-987301272)