### PR TITLE
Update version of github-pages-deploy-action used in templates

### DIFF
--- a/.github/workflows/godot-ci.yml
+++ b/.github/workflows/godot-ci.yml
@@ -85,11 +85,10 @@ jobs:
         run: |
           apt-get update && apt-get install -y rsync
       - name: Deploy to GitHub Pages 🚀
-        uses: JamesIves/github-pages-deploy-action@releases/v3
+        uses: JamesIves/github-pages-deploy-action@releases/v4
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages # The branch the action should deploy to.
-          FOLDER: build/web # The folder the action should deploy.
+          branch: gh-pages # The branch the action should deploy to.
+          folder: build/web # The folder the action should deploy.
 
   export-mac:
     name: Mac Export


### PR DESCRIPTION
The last release of v3 was in 2020.

This PR follows the migration guide: https://github.com/JamesIves/github-pages-deploy-action/discussions/592.
The input parameters are now lowercase, and the token is now automatically taken from the environment.