### PR TITLE
Update Java version to 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     wget \
     zip \
     adb \
-    openjdk-8-jdk-headless \
+    openjdk-11-jdk-headless \
     rsync \
     && rm -rf /var/lib/apt/lists/*
 
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 ENV GODOT_VERSION "3.4.2"
 
 RUN wget https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}/Godot_v${GODOT_VERSION}-stable_linux_headless.64.zip \


### PR DESCRIPTION
I got a problem related to Android Release with custom build template.

```
* What went wrong:
A problem occurred evaluating root project 'build'.
> Failed to apply plugin 'com.android.internal.application'.
   > Android Gradle plugin requires Java 11 to run. You are currently using Java 1.8.
     You can try some of the following options:
       - changing the IDE settings.
       - changing the JAVA_HOME environment variable.
       - changing `org.gradle.java.home` in `gradle.properties`.
```

The solution is simple to install jdk-11 instead of jdk-8. Jdk8 is almost out of support anyway