### PR TITLE
Automate image release process

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -2,7 +2,9 @@ name: "Check Releases"
 on:
   schedule:
     - cron: '27 23 * * *'
-
+  push:
+    branches:
+      - master
 jobs:
   fetch:
     name: Fetch Latest Godot Engine Release
@@ -51,3 +53,4 @@ jobs:
         with:
           body_path: body.txt
           tag_name: ${{ needs.fetch.outputs.release_tag }}
+          token: ${{ secrets.PAT }}

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -1,0 +1,53 @@
+name: "Check Releases"
+on:
+  schedule:
+    - cron: '27 23 * * *'
+
+jobs:
+  fetch:
+    name: Fetch Latest Godot Engine Release
+    runs-on: ubuntu-latest
+    outputs:
+      release_tag: ${{ steps.parse.outputs.tag }}
+      json: ${{ steps.get_latest_release.outputs.data }}
+    steps:
+      - uses: octokit/request-action@v2.x
+        id: get_latest_release
+        with:
+          route: GET /repos/godotengine/godot/releases/latest
+          owner: octokit
+          repo: request-action
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+      - id: parse
+        run: |
+          TAG=$(echo '${{ steps.get_latest_release.outputs.data }}' | jq --raw-output .tag_name)
+          echo "::set-output name=tag::$TAG"
+  current:
+    name: Fetch Current Godot CI release
+    runs-on: ubuntu-latest
+    outputs:
+      release_tag: ${{ steps.parse.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - id: parse 
+        run: echo "::set-output name=tag::$(git tag --list --sort=-creatordate | head --lines 1)" 
+  create:
+    needs: [fetch, current]
+    name: Create New Godot CI Release
+    runs-on: ubuntu-latest
+    if: needs.fetch.outputs.release_tag != needs.current.outputs.release_tag 
+    steps:
+      - uses: actions/checkout@v3
+      - run: echo '${{ needs.fetch.outputs.json }}' | jq --raw-output .body | sed 's/\\r\\n/\n/g' > body.txt
+      - run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git tag ${{ needs.fetch.outputs.release_tag }}
+          git push
+      - uses: softprops/action-gh-release@v0.1.14
+        with:
+          body_path: body.txt
+          tag_name: ${{ needs.fetch.outputs.release_tag }}

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   fetch:
     name: Fetch Latest Godot Engine Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       release_tag: ${{ steps.parse.outputs.tag }}
       json: ${{ steps.get_latest_release.outputs.data }}
@@ -25,7 +25,7 @@ jobs:
           echo "::set-output name=tag::$TAG"
   current:
     name: Fetch Current Godot CI release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       release_tag: ${{ steps.parse.outputs.tag }}
     steps:
@@ -37,7 +37,7 @@ jobs:
   create:
     needs: [fetch, current]
     name: Create New Godot CI Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: needs.fetch.outputs.release_tag != needs.current.outputs.release_tag 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/godot-ci.yml
+++ b/.github/workflows/godot-ci.yml
@@ -8,7 +8,7 @@ env:
 jobs:
   export-windows:
     name: Windows Export
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     container:
       image: barichello/godot-ci:3.3.4
     steps:
@@ -33,7 +33,7 @@ jobs:
 
   export-linux:
     name: Linux Export
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     container:
       image: barichello/godot-ci:3.3.4
     steps:
@@ -58,7 +58,7 @@ jobs:
 
   export-web:
     name: Web Export
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     container:
       image: barichello/godot-ci:3.3.4
     steps:
@@ -91,7 +91,7 @@ jobs:
 
   export-mac:
     name: Mac Export
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     container:
       image: barichello/godot-ci:3.3.4
     steps:

--- a/.github/workflows/godot-ci.yml
+++ b/.github/workflows/godot-ci.yml
@@ -80,6 +80,9 @@ jobs:
         with:
           name: web
           path: build/web
+      - name: Install rsync 📚
+        run: |
+          apt-get update && apt-get install -y rsync
       - name: Deploy to GitHub Pages 🚀
         uses: JamesIves/github-pages-deploy-action@releases/v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ env:
 jobs:
   version:
     name: Get Version
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       version: ${{ steps.calculate.outputs.version }}
       release_name: ${{ steps.calculate.outputs.release_name }}
@@ -19,7 +19,7 @@ jobs:
           echo "::set-output name=release_name::${REF_NAME#*-}"
   build:
     name: Build Image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [version]
     steps:
       - uses: actions/checkout@v3
@@ -50,7 +50,7 @@ jobs:
             GODOT_VERSION=${{ needs.version.outputs.version }}
   build-mono:
     name: Build Mono Image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [version]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@ name: Release
 on:
   release:
     types: [released]
+env:
+  IMAGE_NAME: godot-ci
 jobs:
   version:
     name: Get Version
@@ -10,9 +12,72 @@ jobs:
       version: ${{ steps.calculate.outputs.version }}
       release_name: ${{ steps.calculate.outputs.release_name }}
     steps:
-      - run: CLEAN=`sed -e 's/^v//' <<< $GITHUB_REF`
       - id: calculate
         run: |
-          echo "::set-output name=version::${CLEAN%-*}"
-          echo "::set-output name=release_name::${CLEAN#*-}"
-  
+          REF_NAME=${{ github.ref_name }}
+          echo "::set-output name=version::${REF_NAME%-*}"
+          echo "::set-output name=release_name::${REF_NAME#*-}"
+  build:
+    name: Build Image
+    runs-on: ubuntu-latest
+    needs: [version]
+    steps:
+      - uses: actions/checkout@v3
+      - run:  echo IMAGE_OWNER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
+      - name: Login to GitHub Container Registry 
+        uses: docker/login-action@v1.14.1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v2.9.0
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}:${{ needs.version.outputs.version }}
+            ghcr.io/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:${{ needs.version.outputs.version }}
+          build-args: |
+            GODOT_VERSION=${{ needs.version.outputs.version }}
+  build-mono:
+    name: Build Mono Image
+    runs-on: ubuntu-latest
+    needs: [version]
+    steps:
+      - uses: actions/checkout@v3
+      - run:  echo IMAGE_OWNER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
+      - name: Login to GitHub Container Registry 
+        uses: docker/login-action@v1.14.1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v2.9.0
+        with:
+          context: .
+          file: mono.Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}:mono-${{ needs.version.outputs.version }}
+            ghcr.io/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}:mono-latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:mono-latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:mono-${{ needs.version.outputs.version }}
+          build-args: |
+            GODOT_VERSION=${{ needs.version.outputs.version }}
+            RELEASE_NAME=${{ needs.version.outputs.release_name }}
+            

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,18 @@
+name: Release
+on:
+  release:
+    types: [released]
+jobs:
+  version:
+    name: Get Version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.calculate.outputs.version }}
+      release_name: ${{ steps.calculate.outputs.release_name }}
+    steps:
+      - run: CLEAN=`sed -e 's/^v//' <<< $GITHUB_REF`
+      - id: calculate
+        run: |
+          echo "::set-output name=version::${CLEAN%-*}"
+          echo "::set-output name=release_name::${CLEAN#*-}"
+  

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
-ENV GODOT_VERSION "3.4.2"
+ARG GODOT_VERSION="3.4.2"
 
 RUN wget https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}/Godot_v${GODOT_VERSION}-stable_linux_headless.64.zip \
     && wget https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}/Godot_v${GODOT_VERSION}-stable_export_templates.tpz \

--- a/mono.Dockerfile
+++ b/mono.Dockerfile
@@ -17,11 +17,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # When in doubt see the downloads page
 # https://downloads.tuxfamily.org/godotengine/
-ENV GODOT_VERSION "3.4.2"
+ARG GODOT_VERSION="3.4.2"
 
 # Example values: stable, beta3, rc1, alpha2, etc.
 # Also change the SUBDIR property when NOT using stable
-ENV RELEASE_NAME "stable"
+ARG RELEASE_NAME="stable"
 
 # This is only needed for non-stable builds (alpha, beta, RC)
 # e.g. SUBDIR "/beta3"


### PR DESCRIPTION
This PR resolves #65 and #75 by adding a workflow `.github/workflows/check-release.yml` that runs every night at 23:27 UTC and compares the tag in the latest release of https://github.com/godotengine/godot/releases with the latest tag in this repository. Ideally we would be notified of new releases, but it looks like this would require setting up a [`repository_dispatch`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#repository_dispatch) event on the main Godot repo or something similar.

In case the two tags differ, it will automatically create an equivalent tag in this repository and generate a new release. The body of the release is copied from the release in the engine repository. 

When a new release is created `.github/workflows/release.yml` is triggered. This workflow will build the regular and mono Dockerfiles and push the images both to DockerHub **and GitHub Container Registry**.

The following needs to be added to the repository secrets:
- `DOCKERHUB_USERNAME`
- `DOCKERHUB_TOKEN` can be generated in your docker account settings https://hub.docker.com/settings/security
- `PAT` is a [GitHub Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token), with the following [permissions ](https://aws1.discourse-cdn.com/github/original/3X/b/e/bea4012188e31f2d48d09707795dfb22b3088692.png)

Naturally, DockerHub allows generating only 1 token for a free account 😅 which together with a limited number of pulls for anonymous users is the reason for adding a push to GitHub Container Registry as an alternative.