### PR TITLE
Add a Manual Build workflow

### DIFF
--- a/.github/workflows/manual_build.yml
+++ b/.github/workflows/manual_build.yml
@@ -1,26 +1,22 @@
-name: Release
+name: Manual Build
 on:
-  release:
-    types: [released]
+ workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version of engine to build e.g. "3.4.4", "3.5"'     
+        required: true
+        type: string
+      release_name:
+        description: 'Release name, usually "stable", but can also be something like "rc3", "beta1"'
+        type: string
+        default: "stable"
+        required: true
 env:
   IMAGE_NAME: godot-ci
 jobs:
-  version:
-    name: Get Version
-    runs-on: ubuntu-20.04
-    outputs:
-      version: ${{ steps.calculate.outputs.version }}
-      release_name: ${{ steps.calculate.outputs.release_name }}
-    steps:
-      - id: calculate
-        run: |
-          REF_NAME=${{ github.ref_name }}
-          echo "::set-output name=version::${REF_NAME%-*}"
-          echo "::set-output name=release_name::${REF_NAME#*-}"
   build:
     name: Build Image
     runs-on: ubuntu-20.04
-    needs: [version]
     steps:
       - uses: actions/checkout@v3
       - run:  echo IMAGE_OWNER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
@@ -35,6 +31,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - run:  echo IMAGE_TAG=$(echo ${{ github.event.inputs.release_name != 'stable' && format('.{0}', github.event.inputs.release_name) || '' }}) >> $GITHUB_ENV
       - name: Build and push Docker images
         uses: docker/build-push-action@v2.9.0
         with:
@@ -42,17 +39,15 @@ jobs:
           file: Dockerfile
           push: true
           tags: |
-            ghcr.io/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}:${{ needs.version.outputs.version }}
-            ghcr.io/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}:latest
-            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:latest
-            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:${{ needs.version.outputs.version }}
+            ghcr.io/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}:${{ github.event.inputs.version }}${{ env.IMAGE_TAG }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:${{ github.event.inputs.version }}${{ env.IMAGE_TAG }}
           build-args: |
-            GODOT_VERSION=${{ needs.version.outputs.version }}
-            RELEASE_NAME=${{ needs.version.outputs.release_name }}
+            GODOT_VERSION=${{ github.event.inputs.version }}
+            RELEASE_NAME=${{ github.event.inputs.release_name }}
+            SUBDIR=${{  github.event.inputs.release_name != 'stable' && format('/{0}', github.event.inputs.release_name) || '' }}
   build-mono:
     name: Build Mono Image
     runs-on: ubuntu-20.04
-    needs: [version]
     steps:
       - uses: actions/checkout@v3
       - run:  echo IMAGE_OWNER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
@@ -67,6 +62,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - run:  echo IMAGE_TAG=$(echo ${{ github.event.inputs.release_name != 'stable' && format('.{0}', github.event.inputs.release_name) || '' }}) >> $GITHUB_ENV
       - name: Build and push Docker images
         uses: docker/build-push-action@v2.9.0
         with:
@@ -74,11 +70,10 @@ jobs:
           file: mono.Dockerfile
           push: true
           tags: |
-            ghcr.io/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}:mono-${{ needs.version.outputs.version }}
-            ghcr.io/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}:mono-latest
-            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:mono-latest
-            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:mono-${{ needs.version.outputs.version }}
+            ghcr.io/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}:mono-${{ github.event.inputs.version }}${{ env.IMAGE_TAG }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:mono-${{ github.event.inputs.version }}${{ env.IMAGE_TAG }}
           build-args: |
-            GODOT_VERSION=${{ needs.version.outputs.version }}
-            RELEASE_NAME=${{ needs.version.outputs.release_name }}
+            GODOT_VERSION=${{ github.event.inputs.version }}
+            RELEASE_NAME=${{ github.event.inputs.release_name }}
+            SUBDIR=${{  github.event.inputs.release_name != 'stable' && format('/{0}', github.event.inputs.release_name) || '' }}
             

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,18 +18,21 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
-ARG GODOT_VERSION="3.4.2"
 
-RUN wget https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}/Godot_v${GODOT_VERSION}-stable_linux_headless.64.zip \
-    && wget https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}/Godot_v${GODOT_VERSION}-stable_export_templates.tpz \
+ARG GODOT_VERSION="3.4.2"
+ARG RELEASE_NAME="stable"
+ARG SUBDIR=""
+
+RUN wget https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}${SUBDIR}/Godot_v${GODOT_VERSION}-${RELEASE_NAME}_linux_headless.64.zip \
+    && wget https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}${SUBDIR}/Godot_v${GODOT_VERSION}-${RELEASE_NAME}_export_templates.tpz \
     && mkdir ~/.cache \
     && mkdir -p ~/.config/godot \
-    && mkdir -p ~/.local/share/godot/templates/${GODOT_VERSION}.stable \
-    && unzip Godot_v${GODOT_VERSION}-stable_linux_headless.64.zip \
-    && mv Godot_v${GODOT_VERSION}-stable_linux_headless.64 /usr/local/bin/godot \
-    && unzip Godot_v${GODOT_VERSION}-stable_export_templates.tpz \
-    && mv templates/* ~/.local/share/godot/templates/${GODOT_VERSION}.stable \
-    && rm -f Godot_v${GODOT_VERSION}-stable_export_templates.tpz Godot_v${GODOT_VERSION}-stable_linux_headless.64.zip
+    && mkdir -p ~/.local/share/godot/templates/${GODOT_VERSION}.${RELEASE_NAME} \
+    && unzip Godot_v${GODOT_VERSION}-${RELEASE_NAME}_linux_headless.64.zip \
+    && mv Godot_v${GODOT_VERSION}-${RELEASE_NAME}_linux_headless.64 /usr/local/bin/godot \
+    && unzip Godot_v${GODOT_VERSION}-${RELEASE_NAME}_export_templates.tpz \
+    && mv templates/* ~/.local/share/godot/templates/${GODOT_VERSION}.${RELEASE_NAME} \
+    && rm -f Godot_v${GODOT_VERSION}-${RELEASE_NAME}_export_templates.tpz Godot_v${GODOT_VERSION}-${RELEASE_NAME}_linux_headless.64.zip
 
 ADD getbutler.sh /opt/butler/getbutler.sh
 RUN bash /opt/butler/getbutler.sh

--- a/mono.Dockerfile
+++ b/mono.Dockerfile
@@ -26,7 +26,7 @@ ARG RELEASE_NAME="stable"
 # This is only needed for non-stable builds (alpha, beta, RC)
 # e.g. SUBDIR "/beta3"
 # Use an empty string "" when the RELEASE_NAME is "stable"
-ENV SUBDIR ""
+ARG SUBDIR=""
 
 RUN wget https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}${SUBDIR}/mono/Godot_v${GODOT_VERSION}-${RELEASE_NAME}_mono_linux_headless_64.zip \
     && wget https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}${SUBDIR}/mono/Godot_v${GODOT_VERSION}-${RELEASE_NAME}_mono_export_templates.tpz


### PR DESCRIPTION
adds `.github/workflows/manual_build.yml` which allows manually generating docker images for specific Godot versions. 
![image](https://user-images.githubusercontent.com/2500134/171995400-e802546c-9c6b-4f97-893d-8835ae3cae79.png)

The primary use case of this is creating images for pre-release builds since they are not marked with a release in the official GitHub repository. It's also a useful way of generating images for any release that might have gotten skipped, such as https://github.com/abarichello/godot-ci/issues/75

the generated images will be tagged with the release name, unless the release name is `stable`

- **3.5 rc3** -> `godot-ci:3.5.rc3` & `godot-ci:mono-3.5.rc3`
- **3.4.4 stable** -> `godot-ci:3.4.4` & `godot-ci:mono-3.4.4` 