### PR TITLE
Add missing step to C#/Mono tutorial in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,14 @@ https://hub.docker.com/r/barichello/godot-ci/
 
 ### Mono/C#
 
-To build a godot project with Mono enabled, change the image tag from `barichello/godot-ci:VERSION` to `barichello/godot-ci:mono-VERSION` in `.gitlab-ci.yml` (Gitlab) or `godot-ci.yml` (Github). e.g. `barichello/godot-ci:mono-3.2.1`.
+To build a godot project with Mono enabled, you must do two things for each job:
+1. Change the container's `image` tag from `barichello/godot-ci:VERSION` to `barichello/godot-ci:mono-VERSION` in `.gitlab-ci.yml` (Gitlab) or `godot-ci.yml` (Github). (e.g. `barichello/godot-ci:mono-3.2.1`). 
+2. You will also need to change your "Setup" step's run commands (looks like `run: mv /root/.local ...`) from ending with `...${GODOT_VERSION}.stable` to ending with `...${GODOT_VERSION}.stable.mono`. You will need to do this for both directories in the command. 
+  ```
+  mv /root/.local/share/godot/templates/${GODOT_VERSION}.stable ~/.local/share/godot/templates/${GODOT_VERSION}.stable
+  becomes
+  mv /root/.local/share/godot/templates/${GODOT_VERSION}.stable.mono ~/.local/share/godot/templates/${GODOT_VERSION}.stable.mono
+  ```
 
 ### Android
 

--- a/README.md
+++ b/README.md
@@ -18,14 +18,11 @@ https://hub.docker.com/r/barichello/godot-ci/
 
 ### Mono/C#
 
-To build a godot project with Mono enabled, you must do two things for each job:
+To build a Godot project with Mono (C#) enabled, you must do two things for each job:
 1. Change the container's `image` tag from `barichello/godot-ci:VERSION` to `barichello/godot-ci:mono-VERSION` in `.gitlab-ci.yml` (Gitlab) or `godot-ci.yml` (Github). (e.g. `barichello/godot-ci:mono-3.2.1`). 
 2. You will also need to change your "Setup" step's run commands (looks like `run: mv /root/.local ...`) from ending with `...${GODOT_VERSION}.stable` to ending with `...${GODOT_VERSION}.stable.mono`. You will need to do this for both directories in the command. 
-  ```
+  ```bash
   mv /root/.local/share/godot/templates/${GODOT_VERSION}.stable ~/.local/share/godot/templates/${GODOT_VERSION}.stable
-  becomes
-  mv /root/.local/share/godot/templates/${GODOT_VERSION}.stable.mono ~/.local/share/godot/templates/${GODOT_VERSION}.stable.mono
-  ```
 
 ### Android
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,13 @@ https://hub.docker.com/r/barichello/godot-ci/
 To build a Godot project with Mono (C#) enabled, you must do two things for each job:
 1. Change the container's `image` tag from `barichello/godot-ci:VERSION` to `barichello/godot-ci:mono-VERSION` in `.gitlab-ci.yml` (Gitlab) or `godot-ci.yml` (Github). (e.g. `barichello/godot-ci:mono-3.2.1`). 
 2. You will also need to change your "Setup" step's run commands (looks like `run: mv /root/.local ...`) from ending with `...${GODOT_VERSION}.stable` to ending with `...${GODOT_VERSION}.stable.mono`. You will need to do this for both directories in the command. 
-  ```bash
-  mv /root/.local/share/godot/templates/${GODOT_VERSION}.stable ~/.local/share/godot/templates/${GODOT_VERSION}.stable
+```bash
+mv /root/.local/share/godot/templates/${GODOT_VERSION}.stable ~/.local/share/godot/templates/${GODOT_VERSION}.stable
+```
+becomes:
+```bash
+mv /root/.local/share/godot/templates/${GODOT_VERSION}.stable.mono ~/.local/share/godot/templates/${GODOT_VERSION}.stable.mono
+```
 
 ### Android
 


### PR DESCRIPTION
Previously, the detail that you had to change .stable to .stable.mono in the Setup steps directory structure was not listed and was very confusing for me until I found an issue from some time ago ( https://github.com/abarichello/godot-ci/issues/29#issuecomment-680315417 ) that stated this solution but was never addressed. I hope this can save people some trouble in the future.