### PR TITLE
Use GitHub CLI to fetch release information

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -11,19 +11,12 @@ jobs:
     runs-on: ubuntu-20.04
     outputs:
       release_tag: ${{ steps.parse.outputs.tag }}
-      json: ${{ steps.get_latest_release.outputs.data }}
-    steps:
-      - uses: octokit/request-action@v2.x
-        id: get_latest_release
-        with:
-          route: GET /repos/godotengine/godot/releases/latest
-          owner: octokit
-          repo: request-action
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+    steps:    
       - id: parse
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          TAG=$(echo '${{ steps.get_latest_release.outputs.data }}' | jq --raw-output .tag_name)
+          TAG=$(gh release view --repo godotengine/godot --json tagName --jq .tagName)
           echo "::set-output name=tag::$TAG"
   current:
     name: Fetch Current Godot CI release
@@ -43,7 +36,9 @@ jobs:
     if: needs.fetch.outputs.release_tag != needs.current.outputs.release_tag 
     steps:
       - uses: actions/checkout@v3
-      - run: echo '${{ needs.fetch.outputs.json }}' | jq --raw-output .body | sed 's/\\r\\n/\n/g' > body.txt
+      - run: gh release view --repo godotengine/godot --json body --jq .body | sed 's/\\r\\n/\n/g' > body.txt
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: |
           git config user.name github-actions
           git config user.email github-actions@github.com


### PR DESCRIPTION
Fixes #91 

The root cause of the issue was in the fact that GitHub actions doesn't respect shell scripting conventions, but instead replaces `${{ whatever }}` by injecting the value of the variable directly into their generated script. 

This created an issue where a single quote that is used by the workflow to ensure json doesn't get messed up got completed by a single quote in the release description, which in turn created an invalid bash script that the workflow tried to execute. 

Instead of prefetching the release information, the workflow now fetches the body and tag name when necessary, using shell scripting the entire way, avoiding action executor weirdness. 

Once merged, everything **should** run normally at 23:27 