### PR TITLE
use GITHUB_OUTPUT instead of set-output

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -17,7 +17,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG=$(gh release view --repo godotengine/godot --json tagName --jq .tagName)
-          echo "::set-output name=tag::$TAG"
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
   current:
     name: Fetch Current Godot CI release
     runs-on: ubuntu-20.04
@@ -28,7 +28,7 @@ jobs:
         with:
           fetch-depth: 0
       - id: parse 
-        run: echo "::set-output name=tag::$(git tag --list --sort=-creatordate | head --lines 1)" 
+        run: echo "tag=$(git tag --list --sort=-creatordate | head --lines 1)" >> $GITHUB_OUTPUT 
   create:
     needs: [fetch, current]
     name: Create New Godot CI Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,8 @@ jobs:
       - id: calculate
         run: |
           REF_NAME=${{ github.ref_name }}
-          echo "::set-output name=version::${REF_NAME%-*}"
-          echo "::set-output name=release_name::${REF_NAME#*-}"
+          echo "version=${REF_NAME%-*}" >> $GITHUB_OUTPUT
+          echo "release_name=${REF_NAME#*-}" >> $GITHUB_OUTPUT
   build:
     name: Build Image
     runs-on: ubuntu-20.04


### PR DESCRIPTION
While the release action still uses set-output (and shows deprecation warnings accordingly) I figured at least now them deprecation warnings won't be coming from the godot-ci action 😃 