### PR TITLE
Provide support for Godot 4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN wget https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}${SUBDIR}/G
     && mkdir ~/.cache \
     && mkdir -p ~/.config/godot \
     && mkdir -p ~/.local/share/godot/templates/${GODOT_VERSION}.${RELEASE_NAME} \
+    && ln -s ~/.local/share/godot/templates ~/.local/share/godot/export_templates \
     && unzip Godot_v${GODOT_VERSION}-${RELEASE_NAME}_${GODOT_PLATFORM}.zip \
     && mv Godot_v${GODOT_VERSION}-${RELEASE_NAME}_${GODOT_PLATFORM} /usr/local/bin/godot \
     && unzip Godot_v${GODOT_VERSION}-${RELEASE_NAME}_export_templates.tpz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,17 +22,19 @@ ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 ARG GODOT_VERSION="3.4.2"
 ARG RELEASE_NAME="stable"
 ARG SUBDIR=""
+ARG GODOT_TEST_ARGS=""
+ARG GODOT_PLATFORM="linux_headless.64"
 
-RUN wget https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}${SUBDIR}/Godot_v${GODOT_VERSION}-${RELEASE_NAME}_linux_headless.64.zip \
+RUN wget https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}${SUBDIR}/Godot_v${GODOT_VERSION}-${RELEASE_NAME}_${GODOT_PLATFORM}.zip \
     && wget https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}${SUBDIR}/Godot_v${GODOT_VERSION}-${RELEASE_NAME}_export_templates.tpz \
     && mkdir ~/.cache \
     && mkdir -p ~/.config/godot \
     && mkdir -p ~/.local/share/godot/templates/${GODOT_VERSION}.${RELEASE_NAME} \
-    && unzip Godot_v${GODOT_VERSION}-${RELEASE_NAME}_linux_headless.64.zip \
-    && mv Godot_v${GODOT_VERSION}-${RELEASE_NAME}_linux_headless.64 /usr/local/bin/godot \
+    && unzip Godot_v${GODOT_VERSION}-${RELEASE_NAME}_${GODOT_PLATFORM}.zip \
+    && mv Godot_v${GODOT_VERSION}-${RELEASE_NAME}_${GODOT_PLATFORM} /usr/local/bin/godot \
     && unzip Godot_v${GODOT_VERSION}-${RELEASE_NAME}_export_templates.tpz \
     && mv templates/* ~/.local/share/godot/templates/${GODOT_VERSION}.${RELEASE_NAME} \
-    && rm -f Godot_v${GODOT_VERSION}-${RELEASE_NAME}_export_templates.tpz Godot_v${GODOT_VERSION}-${RELEASE_NAME}_linux_headless.64.zip
+    && rm -f Godot_v${GODOT_VERSION}-${RELEASE_NAME}_export_templates.tpz Godot_v${GODOT_VERSION}-${RELEASE_NAME}_${GODOT_PLATFORM}.zip
 
 ADD getbutler.sh /opt/butler/getbutler.sh
 RUN bash /opt/butler/getbutler.sh
@@ -56,7 +58,7 @@ RUN yes | sdkmanager --licenses \
 RUN keytool -keyalg RSA -genkeypair -alias androiddebugkey -keypass android -keystore debug.keystore -storepass android -dname "CN=Android Debug,O=Android,C=US" -validity 9999 \
     && mv debug.keystore /root/debug.keystore
 
-RUN godot -e -q
+RUN godot -e -q ${GODOT_TEST_ARGS}
 RUN echo 'export/android/android_sdk_path = "/usr/lib/android-sdk"' >> ~/.config/godot/editor_settings-3.tres
 RUN echo 'export/android/debug_keystore = "/root/debug.keystore"' >> ~/.config/godot/editor_settings-3.tres
 RUN echo 'export/android/debug_keystore_user = "androiddebugkey"' >> ~/.config/godot/editor_settings-3.tres


### PR DESCRIPTION
Godot 4 is still in beta, but there are some changes that will be in Effect in the Future.

In particular this change is backwards compatible to the existing workflows. In particular linux_headless has been sunset and replaced by the regular linux distribution (linux.x86_64). To run Godot in a headless context, it is now necessary to specify the display-driver to be "headless".

With this change a Workflow can be created for the beta releases of Godot.

The following Workflow File (it's based on the official one) can be used to create an image on ghcr.io now (without this PR).
If you want i can also contribute the changes to the release workflow, so once godot4 has been released, the images can be created automatically:

All in all thanks for creating this container image. Has been a blast in the past already.

```yaml
name: build

env:
  IMAGE_NAME: godot-ci

on:
  workflow_dispatch:
    inputs:
      version:
        description: 'Version of engine to build e.g. "3.4.4", "3.5"'
        required: true
        type: string

      release_name:
        description: 'Release name, usually "stable", but can also be something like "rc3", "beta1"'
        type: string
        default: "stable"
        required: true

      godot_platform:
        description: 'Name of the Platform to download. For Godot 3.X this is linux_headless.64, while for Godot 4 it is linux.x86_64'
        type: string
        default: "linux.x86_64"
        required: true

      godot_args:
        description: 'Appends additional arguments to the Godot invocation running the container running. This allows to specify the display driver in Godot 4+. Otherwise empty'
        type: string
        default: "--display-driver headless"
        required: true


jobs:
  build:
    runs-on: ubuntu-latest

    steps:
      - uses: actions/checkout@v3
        with:
          repository: abarichello/godot-ci

      - name: 'Fork: Add fix for Godot 4'
        run: |
          REPLACE_NEEDLE=linux_headless.64
          sed -i 's/'${REPLACE_NEEDLE}'/${GODOT_PLATFORM}/g' Dockerfile
          sed -i 's/RUN godot -e -q/RUN godot -e -q ${GODOT_TEST_ARGS}/g' Dockerfile
          sed -i '/ARG SUBDIR=""/a ARG GODOT_PLATFORM="'${REPLACE_NEEDLE}'"' Dockerfile
          sed -i '/ARG SUBDIR=""/a ARG GODOT_TEST_ARGS=""' Dockerfile

      - run:  echo IMAGE_OWNER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
      - name: Login to GitHub Container Registry
        uses: docker/login-action@v1.14.1
        with:
          registry: ghcr.io
          username: ${{ github.repository_owner }}
          password: ${{ secrets.GITHUB_TOKEN }}

      - run:  echo IMAGE_TAG=$(echo ${{ github.event.inputs.release_name != 'stable' && format('.{0}', github.event.inputs.release_name) || '' }}) >> $GITHUB_ENV

      - name: Build and push Docker images
        uses: docker/build-push-action@v2.9.0
        with:
          context: .
          file: Dockerfile
          push: true
          tags: |
            ghcr.io/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}:${{ github.event.inputs.version }}${{ env.IMAGE_TAG }}
          build-args: |
            GODOT_VERSION=${{ github.event.inputs.version }}
            RELEASE_NAME=${{ github.event.inputs.release_name }}
            SUBDIR=${{  github.event.inputs.release_name != 'stable' && format('/{0}', github.event.inputs.release_name) || '' }}
            GODOT_PLATFORM=${{ github.event.inputs.godot_platform }}
            GODOT_TEST_ARGS=${{ github.event.inputs.godot_args }}
```