### PR TITLE
Update Release Action for Godot 4.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,8 @@ jobs:
           build-args: |
             GODOT_VERSION=${{ needs.version.outputs.version }}
             RELEASE_NAME=${{ needs.version.outputs.release_name }}
+            GODOT_TEST_ARGS=${{ startsWith( needs.version.outputs.version, "3." ) && "" || "--headless --quit" }}
+            GODOT_PLATFORM=${{ startsWith( needs.version.outputs.version, "3." ) && "linux_headless.64" || "linux.x86_64" }}
   build-mono:
     name: Build Mono Image
     runs-on: ubuntu-20.04
@@ -81,4 +83,6 @@ jobs:
           build-args: |
             GODOT_VERSION=${{ needs.version.outputs.version }}
             RELEASE_NAME=${{ needs.version.outputs.release_name }}
+            GODOT_TEST_ARGS=${{ startsWith( needs.version.outputs.version, "3." ) && "" || "--headless --quit" }}
+            GODOT_PLATFORM=${{ startsWith( needs.version.outputs.version, "3." ) && "linux_headless.64" || "linux.x86_64" }}
             


### PR DESCRIPTION
Recent release action runs have been failing: https://github.com/abarichello/godot-ci/actions/runs/4473942443

Most recent fix for this issue (#104) seems to be missing the piece that would make the release action utilize the changes made. With this update we will provide the new arguments to pull the correct zip for Godot 4.0 and run it with the expected arguments mentioned in #104. 

I included a check to continue supporting `3.X` versions of Godot. 

Of course, let me know if I need to update anything here. Thanks~