### PR TITLE
Fix imports cache for Godot 4

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,7 @@ image: barichello/godot-ci:4.0.2
 cache:
   key: import-assets
   paths:
-    - .import/
+    - .godot/imported/
 
 stages:
   - import-assets
@@ -22,9 +22,6 @@ import-assets:
   stage: import-assets
   script:
     - godot -v -e --quit --headless
-  artifacts:
-    paths:
-      - .import/
 
 linux:
   stage: export


### PR DESCRIPTION
Follow-up to https://github.com/abarichello/godot-ci/pull/107.

I noticed the imports directory wasn't right for Godot 4.