### PR TITLE
Update JDK version required for Godot 4.2 Android exports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     wget \
     zip \
     adb \
-    openjdk-11-jdk-headless \
+    openjdk-17-jdk-headless \
     rsync \
     && rm -rf /var/lib/apt/lists/*
 
-ARG GODOT_VERSION="4.0.2"
+ARG GODOT_VERSION="4.2.1"
 ARG RELEASE_NAME="stable"
 ARG SUBDIR=""
 ARG GODOT_TEST_ARGS=""


### PR DESCRIPTION
I was able to test locally and updating the JDK indeed fixed my export for Android as reported on #131. This PR updates only the package into the Docker file so please let me know if you need any further changes to make it more flexible.
