### PR TITLE
Update GH Action checkout to v4

### DIFF
--- a/.github/workflows/godot-ci.yml
+++ b/.github/workflows/godot-ci.yml
@@ -14,7 +14,7 @@ jobs:
       image: barichello/godot-ci:4.2.1
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           lfs: true
       - name: Setup
@@ -39,7 +39,7 @@ jobs:
       image: barichello/godot-ci:4.2.1
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           lfs: true
       - name: Setup
@@ -64,7 +64,7 @@ jobs:
       image: barichello/godot-ci:4.2.1
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           lfs: true
       - name: Setup
@@ -97,7 +97,7 @@ jobs:
       image: barichello/godot-ci:4.2.1
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           lfs: true
       - name: Setup


### PR DESCRIPTION
So due to solving my previous problem #134 (thank you), I was able to finally setup the pipeline to export.
However, I noticed some warning messages that popped up, stating that the checkout action this project uses is deprecated:

<img width="1128" alt="image" src="https://github.com/abarichello/godot-ci/assets/62069795/6293119a-2284-462a-97a4-5390c97757aa">

So I checked the [link](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/) and it recommended to upgrade the checkout action to a newer release by just [changing the version number](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-versioned-actions)

I tested it on my own project, changing the version number (exporting Windows + macOS) and it works perfectly fine now with the annotations being gone.

I'm not sure if there is anything in the other export platforms that stops them from using checkout v4, so feel free to correct me here, if it's not possible to upgrade!