### PR TITLE
Add support for Gitea selfhosted runners. 

### DIFF
--- a/.gitea/workflows/godot-ci.yml
+++ b/.gitea/workflows/godot-ci.yml
@@ -1,0 +1,112 @@
+name: "godot-ci export"
+on: push
+
+env:
+  GODOT_VERSION: 4.2.2
+  EXPORT_NAME: test-project
+  PROJECT_PATH: test-project
+
+jobs:
+  export-windows:
+    name: Windows Export
+    runs-on: ubuntu-22.04
+    container:
+      image: godot-ci-nodejs:latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          lfs: true
+      - name: Setup
+        run: |
+          mkdir -v -p ~/.local/share/godot/export_templates/
+      - name: Windows Build
+        run: |
+          mkdir -v -p build/windows
+          cd $PROJECT_PATH
+          godot --headless --verbose --export-release "Windows Desktop" ../build/windows/$EXPORT_NAME.exe
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: windows
+          path: build/windows
+
+  export-linux:
+    name: Linux Export
+    runs-on: ubuntu-22.04
+    container:
+      image: godot-ci-nodejs:latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          lfs: true
+      - name: Setup
+        run: |
+          mkdir -v -p ~/.local/share/godot/export_templates/
+      - name: Linux Build
+        run: |
+          mkdir -v -p build/linux
+          cd $PROJECT_PATH
+          godot --headless --verbose --export-release "Linux/X11" ../build/linux/$EXPORT_NAME.x86_64
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: linux
+          path: build/linux
+
+  export-web:
+    name: Web Export
+    runs-on: ubuntu-22.04
+    container:
+      image: godot-ci-nodejs:latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          lfs: true
+      - name: Setup
+        run: |
+          mkdir -v -p ~/.local/share/godot/export_templates/
+      - name: Web Build
+        run: |
+          mkdir -v -p build/web
+          cd $PROJECT_PATH
+          godot --headless --verbose --export-release "Web" ../build/web/index.html
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: web
+          path: build/web
+      - name: Install rsync 📚
+        run: |
+          apt-get update && apt-get install -y rsync
+      - name: Deploy to GitHub Pages 🚀
+        uses: JamesIves/github-pages-deploy-action@releases/v4
+        with:
+          branch: gh-pages # The branch the action should deploy to.
+          folder: build/web # The folder the action should deploy.
+
+  export-mac:
+    name: Mac Export
+    runs-on: ubuntu-22.04
+    container:
+      image: godot-ci-nodejs:latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          lfs: true
+      - name: Setup
+        run: |
+          mkdir -v -p ~/.local/share/godot/export_templates/
+      - name: Mac Build
+        run: |
+          mkdir -v -p build/mac
+          cd $PROJECT_PATH
+          godot --headless --verbose --export-release "macOS" ../build/mac/$EXPORT_NAME.zip
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: mac
+          path: build/mac

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -1,0 +1,17 @@
+# Heads Up
+
+Fork of Godot-CI, made multiple modifications cut and pasted from my personal Gitea repository using Gitea Runners. Spent a decent amount of time getting that working.
+
+
+General overview for anyone who comes across this, Gitea's Godot repository preset will add exports_template.cfg to the gitignore, you ***DO NOT WANT THIS***, it will break the runner as it won't be able to find the preset. There is likely to be issues with proper secret management, however getting things working was my first priority.
+
+
+Changes made:
+
+Modified Docker image (not public, you will have to build it at the moment) as NodeJS is required for Act Runners.
+Changed actions/upload-artifact in the workflow to @v3 as both V1 and V4 break the artifact upload.
+Changed naming to defaults for what Godot outputs as a export preset, if you edit your exports please make sure the --export-release "$PLATFORM" matches your export_presets.cfg file. 
+This is modified specifically for the current latest Godot 4.2.2 build.
+Changes were made and confirmed working for Gitea. I have not tested C# support in any functional manner.
+
+Docker image will need to be built with "docker build -t godot-ci-nodejs ." on the runner host in the /Docker/ folder.

--- a/Docker/dockerfile
+++ b/Docker/dockerfile
@@ -1,0 +1,64 @@
+FROM node:20-bullseye
+LABEL author="https://github.com/aBARICHELLO/godot-ci/graphs/contributors"
+
+USER root
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    git \
+    git-lfs \
+    unzip \
+    wget \
+    zip \
+    adb \
+    openjdk-17-jdk-headless \
+    rsync \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG GODOT_VERSION="4.2.2"
+ARG RELEASE_NAME="stable"
+ARG SUBDIR=""
+ARG GODOT_TEST_ARGS=""
+ARG GODOT_PLATFORM="linux.x86_64"
+
+RUN wget https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}${SUBDIR}/Godot_v${GODOT_VERSION}-${RELEASE_NAME}_${GODOT_PLATFORM}.zip \
+    && wget https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}${SUBDIR}/Godot_v${GODOT_VERSION}-${RELEASE_NAME}_export_templates.tpz \
+    && mkdir ~/.cache \
+    && mkdir -p ~/.config/godot \
+    && mkdir -p ~/.local/share/godot/export_templates/${GODOT_VERSION}.${RELEASE_NAME} \
+    && unzip Godot_v${GODOT_VERSION}-${RELEASE_NAME}_${GODOT_PLATFORM}.zip \
+    && mv Godot_v${GODOT_VERSION}-${RELEASE_NAME}_${GODOT_PLATFORM} /usr/local/bin/godot \
+    && unzip Godot_v${GODOT_VERSION}-${RELEASE_NAME}_export_templates.tpz \
+    && mv templates/* ~/.local/share/godot/export_templates/${GODOT_VERSION}.${RELEASE_NAME} \
+    && rm -f Godot_v${GODOT_VERSION}-${RELEASE_NAME}_export_templates.tpz Godot_v${GODOT_VERSION}-${RELEASE_NAME}_${GODOT_PLATFORM}.zip
+
+ADD getbutler.sh /opt/butler/getbutler.sh
+RUN bash /opt/butler/getbutler.sh
+RUN /opt/butler/bin/butler -V
+
+ENV PATH="/opt/butler/bin:${PATH}"
+
+# Download and setup android-sdk
+ENV ANDROID_HOME="/usr/lib/android-sdk"
+RUN wget https://dl.google.com/android/repository/commandlinetools-linux-7583922_latest.zip \
+    && unzip commandlinetools-linux-*_latest.zip -d cmdline-tools \
+    && mv cmdline-tools $ANDROID_HOME/ \
+    && rm -f commandlinetools-linux-*_latest.zip
+
+ENV PATH="${ANDROID_HOME}/cmdline-tools/cmdline-tools/bin:${PATH}"
+
+RUN yes | sdkmanager --licenses \
+    && sdkmanager "platform-tools" "build-tools;33.0.2" "platforms;android-33" "cmdline-tools;latest" "cmake;3.22.1" "ndk;25.2.9519653"
+
+# Adding android keystore and settings
+RUN keytool -keyalg RSA -genkeypair -alias androiddebugkey -keypass android -keystore debug.keystore -storepass android -dname "CN=Android Debug,O=Android,C=US" -validity 9999 \
+    && mv debug.keystore /root/debug.keystore
+
+RUN godot -v -e --quit --headless ${GODOT_TEST_ARGS}
+RUN echo 'export/android/android_sdk_path = "/usr/lib/android-sdk"' >> ~/.config/godot/editor_settings-4.tres
+RUN echo 'export/android/debug_keystore = "/root/debug.keystore"' >> ~/.config/godot/editor_settings-4.tres
+RUN echo 'export/android/debug_keystore_user = "androiddebugkey"' >> ~/.config/godot/editor_settings-4.tres
+RUN echo 'export/android/debug_keystore_pass = "android"' >> ~/.config/godot/editor_settings-4.tres
+RUN echo 'export/android/force_system_user = false' >> ~/.config/godot/editor_settings-4.tres
+RUN echo 'export/android/timestamping_authority_url = ""' >> ~/.config/godot/editor_settings-4.tres
+RUN echo 'export/android/shutdown_adb_on_exit = true' >> ~/.config/godot/editor_settings-4.tres

--- a/Docker/getbutler.sh
+++ b/Docker/getbutler.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/bash
+
+mkdir -p /opt/butler/bin 
+cd /opt/butler/bin
+
+wget -O butler.zip https://broth.itch.ovh/butler/linux-amd64/LATEST/archive/default
+unzip butler.zip
+
+# GNU unzip tends to not set the executable bit even though it's set in the .zip
+chmod +x butler
+
+export PATH=/opt/butler/bin/:$PATH
+cd ~


### PR DESCRIPTION
Added a modified dockerfile template to fix Act runner crashing due to dependency on NodeJS. Also added brief instructions to a markdown file located in Docker/ folder. Modified workflow template and added working copy to .gitea/workflows/godot-ci.yml
Things I've noted so far while troubleshooting. The workflow file currently in the test-project as an example is not quite right, as the godot --export-release command fails due to platform naming not being the same for macOS and Web (From "Mac OSX" and "HTML5") specifically for Godot 4.2.2 in my testing. Fixed that as the default export_presets.cfg in Godot 4.2.2 for the editor has platform="macOS" and platform="Web". Currently will need to build the docker image manually on the runner host. You will additionally also need to specify a bundle identifier for macOS otherwise the build will fail with the following error:

OSX Error Image
![image](https://github.com/abarichello/godot-ci/assets/145173967/015a58cb-1642-405d-9f60-2576d5d53637)

Feel free to make changes as necessary for standardization.
