### PR TITLE
Added 3.6 CI Version

### DIFF
--- a/.github/workflows/godot-ci.yml
+++ b/.github/workflows/godot-ci.yml
@@ -2,7 +2,7 @@ name: "godot-ci export"
 on: push
 
 env:
-  GODOT_VERSION: 3.3.4
+  GODOT_VERSION: 3.6
   EXPORT_NAME: test-project
 
 jobs:
@@ -10,7 +10,7 @@ jobs:
     name: Windows Export
     runs-on: ubuntu-20.04
     container:
-      image: barichello/godot-ci:3.3.4
+      image: barichello/godot-ci:3.6
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -35,7 +35,7 @@ jobs:
     name: Linux Export
     runs-on: ubuntu-20.04
     container:
-      image: barichello/godot-ci:3.3.4
+      image: barichello/godot-ci:3.6
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -60,7 +60,7 @@ jobs:
     name: Web Export
     runs-on: ubuntu-20.04
     container:
-      image: barichello/godot-ci:3.3.4
+      image: barichello/godot-ci:3.6
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -93,7 +93,7 @@ jobs:
     name: Mac Export
     runs-on: ubuntu-20.04
     container:
-      image: barichello/godot-ci:3.3.4
+      image: barichello/godot-ci:3.6
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/manual_build.yml
+++ b/.github/workflows/manual_build.yml
@@ -3,7 +3,7 @@ on:
  workflow_dispatch:
     inputs:
       version:
-        description: 'Version of engine to build e.g. "3.4.4", "3.5"'     
+        description: 'Version of engine to build e.g. "3.5", "3.6"'     
         required: true
         type: string
       release_name:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: barichello/godot-ci:3.4.2
+image: barichello/godot-ci:3.6
 
 # NOTE: the `cd` command in each build stage is not necessary if your
 # project.godot is at the repo root

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 
-ARG GODOT_VERSION="3.4.2"
+ARG GODOT_VERSION="3.6"
 ARG RELEASE_NAME="stable"
 ARG SUBDIR=""
 

--- a/mono.Dockerfile
+++ b/mono.Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # When in doubt see the downloads page
 # https://downloads.tuxfamily.org/godotengine/
-ARG GODOT_VERSION="3.4.2"
+ARG GODOT_VERSION="3.6"
 
 # Example values: stable, beta3, rc1, alpha2, etc.
 # Also change the SUBDIR property when NOT using stable


### PR DESCRIPTION
Updated godot-ci to use 3.6 + export templates.