### PR TITLE
Fix invalid paths in GitHub Actions and GitLab CI workflow files

### DIFF
--- a/.github/workflows/godot-ci.yml
+++ b/.github/workflows/godot-ci.yml
@@ -1,8 +1,10 @@
 name: "godot-ci export"
 on: push
 
+# NOTE: If your `project.godot` is at the repository root, set `PROJECT_PATH` below to ".".
+
 env:
-  GODOT_VERSION: 4.2.1
+  GODOT_VERSION: 4.3
   EXPORT_NAME: test-project
   PROJECT_PATH: test-project
 
@@ -11,7 +13,7 @@ jobs:
     name: Windows Export
     runs-on: ubuntu-20.04
     container:
-      image: barichello/godot-ci:4.2.1
+      image: barichello/godot-ci:4.3
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -24,8 +26,9 @@ jobs:
       - name: Windows Build
         run: |
           mkdir -v -p build/windows
+          EXPORT_DIR="$(readlink -f build)"
           cd $PROJECT_PATH
-          godot --headless --verbose --export-release "Windows Desktop" ../build/windows/$EXPORT_NAME.exe
+          godot --headless --verbose --export-release "Windows Desktop" "$EXPORT_DIR/windows/$EXPORT_NAME.exe"
       - name: Upload Artifact
         uses: actions/upload-artifact@v1
         with:
@@ -36,7 +39,7 @@ jobs:
     name: Linux Export
     runs-on: ubuntu-20.04
     container:
-      image: barichello/godot-ci:4.2.1
+      image: barichello/godot-ci:4.3
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -49,8 +52,9 @@ jobs:
       - name: Linux Build
         run: |
           mkdir -v -p build/linux
+          EXPORT_DIR="$(readlink -f build)"
           cd $PROJECT_PATH
-          godot --headless --verbose --export-release "Linux/X11" ../build/linux/$EXPORT_NAME.x86_64
+          godot --headless --verbose --export-release "Linux" "$EXPORT_DIR/linux/$EXPORT_NAME.x86_64"
       - name: Upload Artifact
         uses: actions/upload-artifact@v1
         with:
@@ -61,7 +65,7 @@ jobs:
     name: Web Export
     runs-on: ubuntu-20.04
     container:
-      image: barichello/godot-ci:4.2.1
+      image: barichello/godot-ci:4.3
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -74,8 +78,9 @@ jobs:
       - name: Web Build
         run: |
           mkdir -v -p build/web
+          EXPORT_DIR="$(readlink -f build)"
           cd $PROJECT_PATH
-          godot --headless --verbose --export-release "HTML5" ../build/web/index.html
+          godot --headless --verbose --export-release "Web" "$EXPORT_DIR/web/index.html"
       - name: Upload Artifact
         uses: actions/upload-artifact@v1
         with:
@@ -94,7 +99,7 @@ jobs:
     name: Mac Export
     runs-on: ubuntu-20.04
     container:
-      image: barichello/godot-ci:4.2.1
+      image: barichello/godot-ci:4.3
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -107,8 +112,9 @@ jobs:
       - name: Mac Build
         run: |
           mkdir -v -p build/mac
+          EXPORT_DIR="$(readlink -f build)"
           cd $PROJECT_PATH
-          godot --headless --verbose --export-release "Mac OSX" ../build/mac/$EXPORT_NAME.zip
+          godot --headless --verbose --export-release "macOS" "$EXPORT_DIR/mac/$EXPORT_NAME.zip"
       - name: Upload Artifact
         uses: actions/upload-artifact@v1
         with:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,6 @@
-image: barichello/godot-ci:4.0.2
+image: barichello/godot-ci:4.3
 
-# NOTE: the `cd` command in each build stage is not necessary if your
-# project.godot is at the repo root
+# NOTE: If your `project.godot` is at the repository root, set `PROJECT_PATH` below to ".".
 
 # Cache imported assets between runs
 cache:
@@ -16,6 +15,7 @@ stages:
 
 variables:
   EXPORT_NAME: test-project
+  PROJECT_PATH: test-project
 
 # Open the editor to import assets in case the cache was empty or outdated
 import-assets:
@@ -27,8 +27,9 @@ linux:
   stage: export
   script:
     - mkdir -v -p build/linux
-    - cd $EXPORT_NAME
-    - godot --headless --verbose --export-release "Linux/X11" ../build/linux/$EXPORT_NAME.x86_64
+    - EXPORT_DIR="$(readlink -f build)"
+    - cd $PROJECT_PATH
+    - godot --headless --verbose --export-release "Linux" "$EXPORT_DIR/linux/$EXPORT_NAME.x86_64"
   artifacts:
     name: $EXPORT_NAME-$CI_JOB_NAME
     paths:
@@ -38,8 +39,9 @@ windows:
   stage: export
   script:
     - mkdir -v -p build/windows
-    - cd $EXPORT_NAME
-    - godot --headless --verbose --export-release "Windows Desktop" ../build/windows/$EXPORT_NAME.exe
+    - EXPORT_DIR="$(readlink -f build)"
+    - cd $PROJECT_PATH
+    - godot --headless --verbose --export-release "Windows Desktop" "$EXPORT_DIR/windows/$EXPORT_NAME.exe"
   artifacts:
     name: $EXPORT_NAME-$CI_JOB_NAME
     paths:
@@ -49,8 +51,9 @@ mac:
   stage: export
   script:
     - mkdir -v -p build/mac
-    - cd $EXPORT_NAME
-    - godot --headless --verbose --export-release "Mac OSX" ../build/mac/$EXPORT_NAME.zip
+    - EXPORT_DIR="$(readlink -f build)"
+    - cd $PROJECT_PATH
+    - godot --headless --verbose --export-release "macOS" "$EXPORT_DIR/mac/$EXPORT_NAME.zip"
   artifacts:
     name: $EXPORT_NAME-$CI_JOB_NAME
     paths:
@@ -60,8 +63,9 @@ web:
   stage: export
   script:
     - mkdir -v -p build/web
-    - cd $EXPORT_NAME
-    - godot --headless --verbose --export-release "HTML5" ../build/web/index.html
+    - EXPORT_DIR="$(readlink -f build)"
+    - cd $PROJECT_PATH
+    - godot --headless --verbose --export-release "Web" "$EXPORT_DIR/web/index.html"
   artifacts:
     name: $EXPORT_NAME-$CI_JOB_NAME
     paths:
@@ -72,8 +76,9 @@ android_debug:
   stage: export
   script:
     - mkdir -v -p build/android
-    - cd $EXPORT_NAME
-    - godot --headless --verbose --export-debug "Android Debug" ../build/android/$EXPORT_NAME-debug.apk
+    - EXPORT_DIR="$(readlink -f build)"
+    - cd $PROJECT_PATH
+    - godot --headless --verbose --export-debug "Android Debug" "$EXPORT_DIR/android/$EXPORT_NAME-debug.apk"
   artifacts:
     name: $EXPORT_NAME-$CI_JOB_NAME
     paths:
@@ -95,11 +100,12 @@ android:
   script:
     - echo $SECRET_RELEASE_KEYSTORE_BASE64 | base64 --decode > /root/release.keystore
     - mkdir -v -p build/android
-    - cd $EXPORT_NAME
+    - EXPORT_DIR="$(readlink -f build)"
+    - cd $PROJECT_PATH
     - sed 's@keystore/release=".*"@keystore/release="'/root/release.keystore'"@g' -i export_presets.cfg
     - sed 's@keystore/release_user=".*"@keystore/release_user="'$SECRET_RELEASE_KEYSTORE_USER'"@g' -i export_presets.cfg
     - sed 's@keystore/release_password=".*"@keystore/release_password="'$SECRET_RELEASE_KEYSTORE_PASSWORD'"@g' -i export_presets.cfg
-    - godot --headless --verbose --export-release "Android" ../build/android/$EXPORT_NAME.apk
+    - godot --headless --verbose --export-release "Android" $EXPORT_DIR/android/$EXPORT_NAME.apk
   artifacts:
     name: $EXPORT_NAME-$CI_JOB_NAME
     paths:


### PR DESCRIPTION
- Automatically adapt the export folder based on project folder location relative to the repository root.
- Update workflow files to use Godot 4.3.
- Update default export prest names to match Godot 4.0 onwards.

___

- This closes https://github.com/abarichello/godot-ci/issues/144.