### PR TITLE
Update container to use ubuntu 24.04 and official dotnet 8

### DIFF
--- a/mono.Dockerfile
+++ b/mono.Dockerfile
@@ -1,4 +1,4 @@
-FROM mono:latest
+FROM ubuntu:24.04
 LABEL author="https://github.com/aBARICHELLO/godot-ci/graphs/contributors"
 
 USER root
@@ -8,8 +8,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     git \
     git-lfs \
-    python \
-    python-openssl \
+    python3 \
+    python3-openssl \
+    python-is-python3 \
+    dotnet-sdk-8.0 \
     unzip \
     wget \
     zip \


### PR DESCRIPTION
Container uses the ubuntu 24.04 image now. had to update the python packages to python3 (IIRC Ubuntu officially only supports python3 now), added python-is-python3 package so that the python alias still works and things that call python and not python3 will not fail to find the command line.

Package also installs the offical .NET 8 LTS packages. 

tested Android, Windows, Linux, and macOS Builds. all builds are successful, and I was able to run the Windows, Linux, and Android binaries. Sent the macOS binary off to a friend with a mac for testing since I do not own a macOS device. 

