### PR TITLE
bump to newer ubuntu, and godot 4.5, remove rcedit

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   fetch:
     name: Fetch Latest Godot Engine Release
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       release_tag: ${{ steps.parse.outputs.tag }}
     steps:    
@@ -20,7 +20,7 @@ jobs:
           echo "tag=$TAG" >> $GITHUB_OUTPUT
   current:
     name: Fetch Current Godot CI release
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       release_tag: ${{ steps.parse.outputs.tag }}
     steps:
@@ -32,7 +32,7 @@ jobs:
   create:
     needs: [fetch, current]
     name: Create New Godot CI Release
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: needs.fetch.outputs.release_tag != needs.current.outputs.release_tag 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/godot-ci.yml
+++ b/.github/workflows/godot-ci.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   export-windows:
     name: Windows Export
-    runs-on: ubuntu-22.04  # Use 22.04 with godot 4
+    runs-on: ubuntu-24.04  # Use 24.04 with godot 4
     container:
       image: barichello/godot-ci:4.3
     steps:
@@ -39,7 +39,7 @@ jobs:
 
   export-linux:
     name: Linux Export
-    runs-on: ubuntu-22.04  # Use 22.04 with godot 4
+    runs-on: ubuntu-24.04  # Use 24.04 with godot 4
     container:
       image: barichello/godot-ci:4.3
     steps:
@@ -65,7 +65,7 @@ jobs:
 
   export-web:
     name: Web Export
-    runs-on: ubuntu-22.04  # Use 22.04 with godot 4
+    runs-on: ubuntu-24.04  # Use 24.04 with godot 4
     container:
       image: barichello/godot-ci:4.3
     steps:
@@ -99,7 +99,7 @@ jobs:
 
   export-mac:
     name: Mac Export
-    runs-on: ubuntu-22.04  # Use 22.04 with godot 4
+    runs-on: ubuntu-24.04  # Use 24.04 with godot 4
     container:
       image: barichello/godot-ci:4.3
     steps:

--- a/.github/workflows/manual_build.yml
+++ b/.github/workflows/manual_build.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   version:
     name: Get Version
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       dotnet_version: ${{ steps.calculate.outputs.dotnet_version }}
     steps:
@@ -39,7 +39,7 @@ jobs:
           fi       
   get_tags:
     name: Get Tags
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       tags: ${{steps.write_tags.outputs.tags}}
       tags_mono: ${{steps.write_tags_mono.outputs.tags}}
@@ -76,7 +76,7 @@ jobs:
             retention-days: 1
   build:
     name: Build Image
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: get_tags
     steps:
       - uses: actions/download-artifact@v4
@@ -115,7 +115,7 @@ jobs:
             GODOT_PLATFORM=${{ startsWith( github.event.inputs.version, '3.' ) && 'linux_headless.64' || 'linux.x86_64' }}
   build-mono:
     name: Build Mono Image
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [version, get_tags]
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ env:
 jobs:
   version:
     name: Get Version
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.calculate.outputs.version }}
       release_name: ${{ steps.calculate.outputs.release_name }}
@@ -32,7 +32,7 @@ jobs:
           
   build:
     name: Build Image
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [version]
     steps:
       - uses: actions/checkout@v3
@@ -66,7 +66,7 @@ jobs:
             GODOT_PLATFORM=${{ startsWith( needs.version.outputs.version, '3.' ) && 'linux_headless.64' || 'linux.x86_64' }}
   build-mono:
     name: Build Mono Image
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [version]
     steps:
       - uses: actions/checkout@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:jammy
+FROM ubuntu:noble
 LABEL author="https://github.com/aBARICHELLO/godot-ci/graphs/contributors"
 
 USER root
@@ -14,12 +14,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     adb \
     openjdk-17-jdk-headless \
     rsync \
-    wine64 \
     osslsigncode \
     && rm -rf /var/lib/apt/lists/*
 
 # When in doubt, see the downloads page: https://github.com/godotengine/godot-builds/releases/
-ARG GODOT_VERSION="4.4"
+ARG GODOT_VERSION="4.5"
 
 # Example values: stable, beta3, rc1, dev2, etc.
 # Also change the `SUBDIR` argument below when NOT using stable.
@@ -80,7 +79,3 @@ RUN echo 'export/android/force_system_user = false' >> ~/.config/godot/editor_se
 RUN echo 'export/android/timestamping_authority_url = ""' >> ~/.config/godot/editor_settings-${GODOT_VERSION:0:3}.tres
 RUN echo 'export/android/shutdown_adb_on_exit = true' >> ~/.config/godot/editor_settings-${GODOT_VERSION:0:3}.tres
 
-# Download and set up rcedit to change Windows executable icons on export.
-RUN wget https://github.com/electron/rcedit/releases/download/v2.0.0/rcedit-x64.exe -O /opt/rcedit.exe
-RUN echo 'export/windows/rcedit = "/opt/rcedit.exe"' >> ~/.config/godot/editor_settings-${GODOT_VERSION:0:3}.tres
-RUN echo 'export/windows/wine = "/usr/bin/wine64-stable"' >> ~/.config/godot/editor_settings-${GODOT_VERSION:0:3}.tres

--- a/mono.Dockerfile
+++ b/mono.Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE="mcr.microsoft.com/dotnet/sdk:8.0-jammy"
+ARG IMAGE="mcr.microsoft.com/dotnet/sdk:9.0-noble"
 FROM $IMAGE
 LABEL author="https://github.com/aBARICHELLO/godot-ci/graphs/contributors"
 
@@ -15,12 +15,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     openjdk-17-jdk-headless \
     adb \
     rsync \
-    wine64 \
     osslsigncode \
     && rm -rf /var/lib/apt/lists/*
 
 # When in doubt, see the downloads page: https://github.com/godotengine/godot-builds/releases/
-ARG GODOT_VERSION="4.4"
+ARG GODOT_VERSION="4.5"
 
 # Example values: stable, beta3, rc1, dev2, etc.
 # Also change the `SUBDIR` argument below when NOT using stable.
@@ -85,8 +84,3 @@ RUN echo 'export/android/debug_keystore_pass = "android"' >> ~/.config/godot/edi
 RUN echo 'export/android/force_system_user = false' >> ~/.config/godot/editor_settings-${GODOT_VERSION:0:3}.tres
 RUN echo 'export/android/timestamping_authority_url = ""' >> ~/.config/godot/editor_settings-${GODOT_VERSION:0:3}.tres
 RUN echo 'export/android/shutdown_adb_on_exit = true' >> ~/.config/godot/editor_settings-${GODOT_VERSION:0:3}.tres
-
-# Download and set up rcedit to change Windows executable icons on export.
-RUN wget https://github.com/electron/rcedit/releases/download/v2.0.0/rcedit-x64.exe -O /opt/rcedit.exe
-RUN echo 'export/windows/rcedit = "/opt/rcedit.exe"' >> ~/.config/godot/editor_settings-${GODOT_VERSION:0:3}.tres
-RUN echo 'export/windows/wine = "/usr/bin/wine64-stable"' >> ~/.config/godot/editor_settings-${GODOT_VERSION:0:3}.tres


### PR DESCRIPTION
godot 4.5 has released and it removes the rcedit requirement as it can now directly manipulate resources, ubuntu 22.04 is losing extended support in a year so i just bumped that, godot still works fine (tested in distrobox)