### PR TITLE
Updated butler URL

### DIFF
--- a/getbutler.sh
+++ b/getbutler.sh
@@ -3,7 +3,7 @@
 mkdir -p /opt/butler/bin 
 cd /opt/butler/bin
 
-wget -O butler.zip https://broth.itch.ovh/butler/linux-amd64/LATEST/archive/default
+wget -O butler.zip https://broth.itch.zone/butler/linux-amd64/LATEST/archive/default
 unzip butler.zip
 
 # GNU unzip tends to not set the executable bit even though it's set in the .zip


### PR DESCRIPTION
At this moment the https://broth.itch.ovh/butler/ URL in the getbutler.sh script seem to be down. After checking if it's a known issue I've found that this URL was replaced by https://broth.itch.zone/butler/ for a while and the old URL is just a permanent redirection to this other one. Manually checking the new address is working so I assume that it's just the redirection that got broken. As the documentation suggests using the new one anyway (https://itch.io/docs/butler/installing.html#the-automation-friendly-way) I believe it's better to use that to avoid problems like this.